### PR TITLE
Start testing at best scalefactor of the previous slice

### DIFF
--- a/qoa.h
+++ b/qoa.h
@@ -399,7 +399,6 @@ unsigned int qoa_encode_frame(const short *sample_data, qoa_desc *qoa, unsigned 
 				neighboring slices. As an optimization, start testing
 				the best scalefactor of the previous slice first. */
 				int scalefactor = (_scalefactor + best_scalefactor[c]) % 16;
-				scalefactor = _scalefactor;
 
 				/* We have to reset the LMS state to the last known good one
 				before trying each scalefactor, as each pass updates the LMS


### PR DESCRIPTION
I've noticed that, at least on the bandcamp/ files, nearly all slices get scalefactor 1 applied (~75%).

Scalefactor 0 almost never gets used (~0.3%):

![image](https://github.com/phoboslab/qoa/assets/33985458/55e1fe45-aa73-44e4-8daf-87f38727acd3)

It looks a bit different on the synthetic tests, but overall there's a good correlation between neighboring slices.

By starting each slice at the best scalefactor of the previous one, you get a better approximation right away, so you can `break` out of the loop faster.

This change speeds up the encoding by roughly 40%.

Note that the files won't be identical to ones produced by the current version. When two scalefactors produce the same error, it selects the first one, and this changes the testing order and thus the selected slice.