### PR TITLE
Add link to Go implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ and [TypeScript](https://github.com/pfusik/qoa-fu/blob/master/transpiled/QOA.ts)
 - [JohannesFriedrich/qoa4R](https://github.com/JohannesFriedrich/qoa4R) - R
 - [rafaelcaricio/qoaudio](https://github.com/rafaelcaricio/qoaudio) - Pure Rust zero-dependency decoder implementation
 - [AuburnSounds/audio-formats](https://github.com/AuburnSounds/audio-formats) - D library, supports QOA
+- [braheezy/goqoa](https://github.com/braheezy/goqoa) - Go library and CLI tool


### PR DESCRIPTION
Hello! I wrote a Go package for encoding/decoding QOA audio files. There's a small CLI tool as well to interact with QOA files.

I believe I've done enough testing to verify the fidelity of this port:
- Unit tests for the core QOA encoding/decoding logic. One of them does a checksum compare of a file I generate vs one of the files from the sample pack archive found [here](https://qoaformat.org/samples/).
- A script that compares more (and bigger) files. The checksums don't seem to stay consistent at larger file sizes but audibly it all sounds the same.