### PR TITLE
Add Verilog ASIC implementation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ and [TypeScript](https://github.com/pfusik/qoa-fu/blob/master/transpiled/QOA.ts)
 - [AuburnSounds/audio-formats](https://github.com/AuburnSounds/audio-formats) - D library, supports QOA
 - [braheezy/goqoa](https://github.com/braheezy/goqoa) - Go library and CLI tool
 - [HaxelWorks/qoa-python](https://github.com/HaxelWorks/qoa-python) - Python wrapper using cffi
+- [28add11/tt07_qoa_decode](https://github.com/28add11/tt07_qoa_decode) - ASIC decoder, written in Verilog and manufactured with Tiny Tapeout
 
 ## QOA Support in Other Software
 


### PR DESCRIPTION
Hello, 
I've written a decoder in Verilog for the [Tiny Tapeout](https://tinytapeout.com/) program and submitted it for manufacturing into an ASIC! The chip won't be in anyone's hands for a while, so the hardware version is untested, but it works in simulation and I hope that is enough reason to be added. My one concern is that it doesn't handle any files or frames, it only decodes things on a sample by sample basis. I plan to write some code to handle this in the future, but for now I hope this qualifies as an "implementation" even with the limited functionality. 
Thanks!