### PR TITLE
Fix bug for target 'clean' for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ CFLAGS_PLAY ?= -std=gnu99 -O3
 
 ifeq ($(OS),Windows_NT)
 	LFLAGS_PLAY ?= # defined in #pragma() in sokol_audio.h
+	EXTS        ?= .exe
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
@@ -41,4 +42,4 @@ $(TARGET_CONV):$(TARGET_CONV).c qoa.h
 
 .PHONY: clean
 clean:
-	$(RM) $(TARGET_PLAY) $(TARGET_CONV)
+	$(RM) $(TARGET_PLAY)$(EXTS) $(TARGET_CONV)$(EXTS)


### PR DESCRIPTION
This fixes a bug where `make clean` does not remove the executables on Windows because they have the '.exe' extension.

Before:

![image](https://github.com/phoboslab/qoa/assets/22916974/17893de2-dc80-48a0-9a29-26c150aa415f)

After:

![image](https://github.com/phoboslab/qoa/assets/22916974/6580e87a-d8d0-494f-8216-6d7c68730fa2)
