### PR TITLE
Add VS Code support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ and [TypeScript](https://github.com/pfusik/qoa-fu/blob/master/transpiled/QOA.ts)
 - [raylib](https://github.com/raysan5/raylib) - supports decoding QOA samples through its [raudio module](https://github.com/raysan5/raylib/blob/master/src/raudio.c)
 - [SerenityOS](https://github.com/SerenityOS/serenity) supports QOA system wide through [QOALoader.h](https://github.com/SerenityOS/serenity/blob/master/Userland/Libraries/LibAudio/QOALoader.h)
 - [Qmmp](https://github.com/TTK-qmmp/qmmp-qoa) - supports decoding QOA samples
+- [Visual Studio Code](https://github.com/microsoft/vscode): supports playing QOA files with the [QOA Preview extension](https://github.com/braheezy/vscode-qoa-preview)


### PR DESCRIPTION
I was working on an 8080 emulator/space invaders project and all the sound assets are QOA files. Afterwards, I realized it would have been mighty convenient to quickly play QOA files in my editor, so I wrote this extension.

Thanks again for the format! It's been fun to play with in different use cases like this.