### PR TITLE
Move memory allocations out of `qoa_encode/decode`

### DIFF
--- a/qoaconv.c
+++ b/qoaconv.c
@@ -256,7 +256,8 @@ int main(int argc, char **argv) {
 		#endif
 	}
 	else if (QOACONV_STR_ENDS_WITH(argv[1], ".qoa")) {
-		sample_data = qoa_read(argv[1], &desc);
+		sample_data = malloc(qoa_decode_size(&desc) * sizeof(short));
+		qoa_read(argv[1], &desc, sample_data);
 	}
 	else {
 		QOACONV_ABORT("Unknown file type for %s", argv[1]);


### PR DESCRIPTION
Normally, both `qoa_encode` and `qoa_decode` allocate memory, doing the encode/decode process then returning a pointer to the result.

This assumes the user's program doesn't have a required custom implementation of memory allocation to store the result, so depending on how it is implemented, two buffers (the one created by `qoa_encode/decode` + the one in the program) end up being necessary, using double memory in the process.

This change moves memory allocations out of `qoa_encode` and `qoa_decode`, modifying them to write to a buffer provided by the user. This way, no unfreed memory allocations are done within `qoa.h`.