### PR TITLE
Fix floating point exceptions

### DIFF
--- a/qoaconv.c
+++ b/qoaconv.c
@@ -273,7 +273,7 @@ int main(int argc, char **argv) {
 	/* Encode output */
 	
 	int bytes_written = 0;
-	double psnr = 1.0/0.0;
+	double psnr = NAN;
 	if (QOACONV_STR_ENDS_WITH(argv[2], ".wav")) {
 		bytes_written = qoaconv_wav_write(argv[2], sample_data, &desc);
 	}
@@ -281,7 +281,8 @@ int main(int argc, char **argv) {
 		bytes_written = qoa_write(argv[2], sample_data, &desc);
 		#ifdef QOA_RECORD_TOTAL_ERROR
 			/* Is this the right way to calculate the PSNR? */
-			psnr = -20.0 * log10(sqrt(desc.error/(desc.samples * desc.channels)) / 32768.0);
+			if (desc.error)
+				psnr = -20.0 * log10(sqrt(desc.error/(desc.samples * desc.channels)) / 32768.0);
 		#endif
 	}
 	else {


### PR DESCRIPTION
On RISC OS with SharedCLibrary (and possibly other platforms), the default behaviour on a floating point exception is to abort the program.