### PR TITLE
Make encoder 1.5% faster by replacing modulo with mask

### DIFF
--- a/qoa.h
+++ b/qoa.h
@@ -402,7 +402,7 @@ unsigned int qoa_encode_frame(const short *sample_data, qoa_desc *qoa, unsigned 
 				/* There is a strong correlation between the scalefactors of
 				neighboring slices. As an optimization, start testing
 				the best scalefactor of the previous slice first. */
-				int scalefactor = (sfi + prev_scalefactor[c]) % 16;
+				int scalefactor = (sfi + prev_scalefactor[c]) & (16 - 1);
 
 				/* We have to reset the LMS state to the last known good one
 				before trying each scalefactor, as each pass updates the LMS


### PR DESCRIPTION
This was tested with a 5min51s Stereo 96kHz FLAC file.

Before this, `qoaconv` takes **2.58-2.59s** to encode. Now it takes **2.54-2.55s**.

This just replaces an operation with a faster one that yields the same result, so quality should stay the same.

`-o3` doesn't seem to catch this because the variable is a signed integer, and can't tell the number is always positive.