### PR TITLE
`qoa_decode_frame()`: Make `frame_len` optional

### DIFF
--- a/qoa.h
+++ b/qoa.h
@@ -580,7 +580,9 @@ unsigned int qoa_decode_header(const unsigned char *bytes, int size, qoa_desc *q
 
 unsigned int qoa_decode_frame(const unsigned char *bytes, unsigned int size, qoa_desc *qoa, short *sample_data, unsigned int *frame_len) {
 	unsigned int p = 0;
-	*frame_len = 0;
+	if (frame_len) {
+		*frame_len = 0;
+	}
 
 	if (size < 8 + QOA_LMS_LEN * 4 * qoa->channels) {
 		return 0;
@@ -645,7 +647,9 @@ unsigned int qoa_decode_frame(const unsigned char *bytes, unsigned int size, qoa
 		}
 	}
 
-	*frame_len = samples;
+	if (frame_len) {
+		*frame_len = samples;
+	}
 	return p;
 }
 


### PR DESCRIPTION
Depending on how the player is implemented, it may not need to know how many frames were decoded, but the current code enforces a target to be provided.

Now it validates the target before attempting to write to it, meaning we just pass `NULL` or an equivalent when not needed.

Does not break API.