### PR TITLE
Fix heap-buffer-overflow in qoa_decode caused by integer wrap-around

### DIFF
--- a/qoa.h
+++ b/qoa.h
@@ -666,8 +666,14 @@ short *qoa_decode(const unsigned char *bytes, int size, qoa_desc *qoa) {
 	}
 
 	/* Calculate the required size of the sample buffer and allocate, round up to full frames */
-	int total_samples = ((qoa->samples + QOA_FRAME_LEN - 1) / QOA_FRAME_LEN) * QOA_FRAME_LEN * qoa->channels;
+	unsigned long long num_frames = ((unsigned long long)qoa->samples + QOA_FRAME_LEN - 1) / QOA_FRAME_LEN;
+	unsigned long long total_samples_ull = num_frames * QOA_FRAME_LEN * (unsigned long long)qoa->channels;
+
+	if (total_samples_ull > 0x7fffffff) { return NULL; }
+
+	unsigned int total_samples = (unsigned int)total_samples_ull;
 	short *sample_data = QOA_MALLOC(total_samples * sizeof(short));
+	if (!sample_data) { return NULL; }
 
 	unsigned int sample_index = 0;
 	unsigned int frame_len;


### PR DESCRIPTION
When qoa->samples is near UINT32_MAX, the sample-buffer size calculation wraps around in 32-bit unsigned arithmetic, resulting in QOA_MALLOC(0) and an out-of-bounds heap write in qoa_decode_frame.

Fix by promoting the arithmetic to 64-bit, capping total_samples at 0x7fffffff (to keep the subsequent * sizeof(short) safe), changing total_samples from int to unsigned int, and adding a NULL check after QOA_MALLOC.